### PR TITLE
[FIX] jQuery Event Fixes

### DIFF
--- a/jQuery2/Events/Browser.cs
+++ b/jQuery2/Events/Browser.cs
@@ -27,6 +27,16 @@ namespace Bridge.jQuery2
         /// <summary>
         /// Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.
         /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        public virtual jQuery Resize(Action<jQueryEvent> handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.
+        /// </summary>
         /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
@@ -62,6 +72,16 @@ namespace Bridge.jQuery2
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
         public virtual jQuery Scroll(Action handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        public virtual jQuery Scroll(Action<jQueryEvent> handler)
         {
             return null;
         }

--- a/jQuery2/Events/Event.cs
+++ b/jQuery2/Events/Event.cs
@@ -55,9 +55,23 @@ namespace Bridge.jQuery2
         }
 
         /// <summary>
-        /// The current DOM element within the event bubbling phase.
+        /// Indicates whether the given event bubbles up through the DOM or not.
+        /// Only certain events can bubble. Events that do bubble have this property set to true. You can use this property to check if an event is allowed to bubble or not.
         /// </summary>
-        public Element CurrentTarget;
+        public readonly bool Bubbles;
+
+        /// <summary>
+        /// Indicates whether the event is cancelable or not.
+        /// Whether an event can be canceled or not is something that's determined when that event is initialized.
+        /// To cancel an event, call the preventDefault() method on the event. This keeps the implementation from executing the default action that is associated with the event.
+        /// </summary>
+        public readonly bool Cancelable;
+
+        /// <summary>
+        /// Identifies the current target for the event, as the event traverses the DOM. It always refers to the element the event handler has been attached to as opposed to event.target which identifies the element on which the event occurred.
+        /// On Internet Explorer 6 through 8, the event model is different. Event listeners are attached with the non-standard element.attachEvent method. In this model, there is no equivalent to event.currentTarget and this is the global object.
+        /// </summary>
+        public readonly Element CurrentTarget;
 
         /// <summary>
         /// An optional object of data passed to an event method when the current executing handler is bound.
@@ -70,10 +84,14 @@ namespace Bridge.jQuery2
         public Element DelegateTarget;
 
         /// <summary>
-        /// Indicates whether the META key was pressed when the event fired.
-        /// Returns a boolean value (true or false) that indicates whether or not the META key was pressed at the time the event fired. This key might map to an alternative key name on some platforms.
+        /// Indicates which phase of the event flow is currently being evaluated.
+        /// Returns an integer value represented by 4 constants:
+        /// Event.NONE = 0
+        /// Event.CAPTURING_PHASE = 1
+        /// Event.AT_TARGET = 2
+        /// Event.BUBBLING_PHASE = 3
         /// </summary>
-        public bool MetaKey;
+        public readonly int EventPhase;
 
         /// <summary>
         /// This will likely be used primarily by plugin authors who wish to handle tasks differently depending on the event namespace used.
@@ -86,6 +104,105 @@ namespace Bridge.jQuery2
         public Event OriginalEvent;
 
         /// <summary>
+        /// The last value returned by an event handler that was triggered by this event, unless the value was undefined.
+        /// </summary>
+        public object Result;
+
+        /// <summary>
+        /// This property of event objects is the object the event was dispatched on. It is different than event.currentTarget when the event handler is called in bubbling or capturing phase of the event.
+        /// On IE6-8, the event model is different. Event listeners are attached with the non-standard element.attachEvent method. In this model, the event object is not passed as an argument to the event handler function but is the window.event object. This object has an srcElement property which has the same semantics than event.target.
+        /// </summary>
+        public readonly Element Target;
+
+        /// <summary>
+        /// Returns the time (in milliseconds since the epoch) at which the event was created.
+        /// This property only works if the event system supports it for the particular event.
+        /// </summary>
+        public readonly int TimeStamp;
+
+        /// <summary>
+        /// Returns a string containing the type of event.
+        /// </summary>
+        public readonly string Type;
+
+        /// <summary>
+        /// Returns whether event.preventDefault() was ever called on this event object.
+        /// </summary>
+        public bool IsDefaultPrevented()
+        {
+          return false;
+        }
+
+        /// <summary>
+        /// Returns whether event.stopImmediatePropagation() was ever called on this event object.
+        /// </summary>
+        public bool IsImmediatePropagationStopped()
+        {
+          return false;
+        }
+
+        /// <summary>
+        /// Returns whether event.stopPropagation() was ever called on this event object.
+        /// </summary>
+        public bool IsPropagationStopped()
+        {
+          return false;
+        }
+
+        /// <summary>
+        /// Cancels the event if it is cancelable, without stopping further propagation of the event.
+        /// </summary>
+        public virtual void PreventDefault()
+        {
+        }
+
+        /// <summary>
+        /// Prevents other listeners of the same event to be called.
+        /// If several listeners are attached to the same element for the same event type, they are called in order in which they have been added. If during one such call, event.stopImmediatePropagation() is called, no remaining listeners will be called.
+        /// </summary>
+        public virtual void StopImmediatePropagation()
+        {
+        }
+
+        /// <summary>
+        /// Prevents further propagation of the current event.
+        /// </summary>
+        public virtual void StopPropagation()
+        {
+        }
+    }
+
+    [Ignore]
+    [Name("jQuery.Event")]
+    public class jQueryUiEvent : jQueryEvent
+    {
+        /// <summary>
+        /// Creates a jQuery Event instance of the specified event
+        /// </summary>
+        /// <param name="eventName">The name of the event</param>
+        [Template("$.Event({0})")]
+        public jQueryUiEvent(string eventName) : base(eventName)
+        {
+        }
+
+        /// <summary>
+        /// Creates a jQuery Event instance of the specified event
+        /// </summary>
+        /// <param name="eventName">The name of the event</param>
+        /// <param name="arguments">A set of settings specific for the event</param>
+        [Template("$.Event({0},{arguments})")]
+        public jQueryUiEvent(string eventName, params object[] arguments) : base(eventName, arguments)
+        {
+        }
+
+        /// <summary>
+        /// Returns additional numerical information about the event, depending on the type of event.
+        /// For mouse events, such as click, dblclick, mousedown, or mouseup, the detail property indicates how many times the mouse has been clicked in the same location for this event.
+        /// For a dblclick event the value of detail is always 2.
+        /// </summary>
+        public readonly int Detail;
+
+        /// <summary>
         /// The mouse position relative to the left edge of the document.
         /// </summary>
         public int PageX;
@@ -94,84 +211,215 @@ namespace Bridge.jQuery2
         /// The mouse position relative to the top edge of the document.
         /// </summary>
         public int PageY;
+    }
 
+    [Ignore]
+    [Name("jQuery.Event")]
+    public class jQueryFocusEvent : jQueryUiEvent
+    {
         /// <summary>
-        /// The other DOM element involved in the event, if any.
+        /// Creates a jQuery Event instance of the specified event
         /// </summary>
-        public Element RelatedTarget;
-
-        /// <summary>
-        /// The last value returned by an event handler that was triggered by this event, unless the value was undefined.
-        /// </summary>
-        public object Result;
-
-        /// <summary>
-        /// The DOM element that initiated the event.
-        /// </summary>
-        public Element Target;
-
-        /// <summary>
-        /// The difference in milliseconds between the time the browser created the event and January 1, 1970.
-        /// This property can be useful for profiling event performance by getting the event.timeStamp value at two points in the code and noting the difference. To simply determine the current time inside an event handler, use (new Date).getTime() instead.
-        /// Note: Due to a bug open since 2004, this value is not populated correctly in Firefox and it is not possible to know the time the event was created in that browser.
-        /// </summary>
-        public double TimeStamp;
-
-        /// <summary>
-        /// Describes the nature of the event.
-        /// </summary>
-        public string Type;
-
-        /// <summary>
-        /// For key or mouse events, this property indicates the specific key or button that was pressed.
-        /// The event.which property normalizes event.keyCode and event.charCode. It is recommended to watch event.which for keyboard key input. For more detail, read about event.charCode on the MDC.
-        /// It also normalizes button presses (mousedown and mouseupevents), reporting 1 for left button, 2 for middle, and 3 for right. Use event.which instead of event.button.
-        /// </summary>
-        public int Which;
-
-        /// <summary>
-        /// Returns whether event.preventDefault() was ever called on this event object.
-        /// </summary>
-        public bool IsDefaultPrevented()
-        {
-            return false;
-        }
-
-        /// <summary>
-        /// Returns whether event.stopImmediatePropagation() was ever called on this event object.
-        /// </summary>
-        public bool IsImmediatePropagationStopped()
-        {
-            return false;
-        }
-
-        /// <summary>
-        /// Returns whether event.stopPropagation() was ever called on this event object.
-        /// </summary>
-        public bool IsPropagationStopped()
-        {
-            return false;
-        }
-
-        /// <summary>
-        /// If this method is called, the default action of the event will not be triggered.
-        /// </summary>
-        public void PreventDefault()
+        /// <param name="eventName">The name of the event</param>
+        [Template("$.Event({0})")]
+        public jQueryFocusEvent(string eventName) : base(eventName)
         {
         }
 
         /// <summary>
-        /// Keeps the rest of the handlers from being executed and prevents the event from bubbling up the DOM tree.
+        /// Creates a jQuery Event instance of the specified event
         /// </summary>
-        public void StopImmediatePropagation()
+        /// <param name="eventName">The name of the event</param>
+        /// <param name="arguments">A set of settings specific for the event</param>
+        [Template("$.Event({0},{arguments})")]
+        public jQueryFocusEvent(string eventName, params object[] arguments) : base(eventName, arguments)
         {
         }
 
         /// <summary>
-        /// Prevents the event from bubbling up the DOM tree, preventing any parent handlers from being notified of the event.
+        /// The FocusEvent.relatedTarget read-only property represents a secondary target for this event, which will depend of the event itself. As in some cases (like when tabbing in or out a page), this property may be set to null for security reasons.
         /// </summary>
-        public void StopPropagation()
+        public readonly Element RelatedTarget;
+    }
+
+    [Ignore]
+    [Name("jQuery.Event")]
+    public class jQueryKeyboardEvent : jQueryUiEvent
+    {
+        /// <summary>
+        /// Creates a jQuery Event instance of the specified event
+        /// </summary>
+        /// <param name="eventName">The name of the event</param>
+        [Template("$.Event({0})")]
+        public jQueryKeyboardEvent(string eventName) : base(eventName)
         {
         }
+
+        /// <summary>
+        /// Creates a jQuery Event instance of the specified event
+        /// </summary>
+        /// <param name="eventName">The name of the event</param>
+        /// <param name="arguments">A set of settings specific for the event</param>
+        [Template("$.Event({0},{arguments})")]
+        public jQueryKeyboardEvent(string eventName, params object[] arguments) : base(eventName, arguments)
+        {
+        }
+
+        /// <summary>
+        /// Indicates whether the ALT key was pressed when the event fired.
+        /// </summary>
+        public readonly bool AltKey;
+
+        /// <summary>
+        /// The Unicode reference number of the key; this attribute is used only by the 'keypress' event. For keys whose char attribute contains multiple characters, this is the Unicode value of the first character in that attribute. In Firefox 26 this returns codes for printable characters.
+        /// </summary>
+        public readonly int CharCode;
+
+        /// <summary>
+        /// Indicates whether the CTRL key was pressed when the event fired.
+        /// </summary>
+        public readonly bool CtrlKey;
+
+        /// <summary>
+        /// Returns the Unicode value of a non-character key in a keypress event or any key in any other type of keyboard event.
+        ///
+        /// In a keypress event, the Unicode value of the key pressed is stored in either the keyCode or charCode property, never both. If the key pressed generates a character (e.g. 'a'), charCode is set to the code of that character, respecting the letter case. (i.e. charCode takes into account whether the shift key is held down). Otherwise, the code of the pressed key is stored in keyCode.
+        ///
+        /// keyCode is always set in the keydown and keyup events. In these cases, charCode is never set.
+        ///
+        /// To get the code of the key regardless of whether it was stored in keyCode or charCode, query the which property.
+        ///
+        /// Characters entered through an IME do not register through keyCode or charCode.
+        /// </summary>
+        public readonly int KeyCode;
+
+        /// <summary>
+        /// The key value of the key represented by the event. If the value has a printed representation, this attribute's value is the same as the char attribute. Otherwise, it's one of the key value strings specified in {{anch("Key values")}}. If the key can't be identified, this is the string "Unidentified". See key names for the detail. In Firefox 26 this has a valid string for non-printable characters, and some printable characters (e.g. Tab, Enter). For regular characters it returns only "MozPrintableKey". charCode works and returns the character code.
+        /// </summary>
+        public readonly string Key;
+
+        /// <summary>
+        /// Indicates whether the "meta" key was pressed when the event fired.
+        /// Note: On the Macintosh, this is the Command key. On Microsoft Windows, this is the Windows key.
+        /// </summary>
+        public readonly bool MetaKey;
+
+        /// <summary>
+        /// Indicates whether the SHIFT key was pressed when the event fired.
+        /// </summary>
+        public readonly bool ShiftKey;
+
+        /// <summary>
+        /// Returns the numeric keyCode of the key pressed, or the character code (charCode) for an alphanumeric key pressed.
+        /// </summary>
+        public readonly int Which;
+    }
+
+    [Ignore]
+    [Name("jQuery.Event")]
+    public class jQueryMouseEvent : jQueryUiEvent
+    {
+        /// <summary>
+        /// Creates a jQuery Event instance of the specified event
+        /// </summary>
+        /// <param name="eventName">The name of the event</param>
+        [Template("$.Event({0})")]
+        public jQueryMouseEvent(string eventName) : base(eventName)
+        {
+        }
+
+        /// <summary>
+        /// Creates a jQuery Event instance of the specified event
+        /// </summary>
+        /// <param name="eventName">The name of the event</param>
+        /// <param name="arguments">A set of settings specific for the event</param>
+        [Template("$.Event({0},{arguments})")]
+        public jQueryMouseEvent(string eventName, params object[] arguments) : base(eventName, arguments)
+        {
+        }
+
+        /// <summary>
+        /// Indicates whether the ALT key was pressed when the event fired.
+        /// </summary>
+        public readonly bool AltKey;
+
+        /// <summary>
+        /// Indicates which mouse button caused the event.
+        /// This property returns an integer value indicating the button that changed state.
+        ///
+        ///        0 for standard "click"; this is usually the left button for a right-handed mouse and right button for a left-handed mouse.
+        ///        1 for middle button; this is usually a click on the scroll wheel's button.
+        ///        2 for right button; this is usually a right-click on a right-handed mouse and left-click on a left-handed mouse.
+        ///
+        /// Note: This convention is not followed in Internet Explorer prior to version 9: See QuirksMode for details (http://www.quirksmode.org/js/events_properties.html#button).
+        ///
+        /// Notes
+        ///
+        /// Because mouse clicks are frequently intercepted by the user interface, it may be difficult to detect buttons other than those for a standard mouse click (usually the left button) in some circumstances.
+        ///
+        /// Users may change the configuration of buttons on their pointing device so that if an event's button property is zero, it may not have been caused by the button that is physically left–most on the pointing device; however, it should behave as if the left button was clicked in the standard button layout.
+        /// </summary>
+        public readonly int Button;
+
+        /// <summary>
+        /// The buttons being pressed when the mouse event was fired
+        /// Each button that can be pressed is representd by a given number (see below). If more than one button is pressed, the value of the buttons is combined to produce a new number. For example, if the right button (2) and the wheel button (4) are pressed, the value is equal to 2|4, which is 6.
+        /// A number representing one or more buttons. For more than one button pressed, the values are combined.
+        ///
+        /// 1  : Left button
+        /// 2  : Right button
+        /// 4  : Wheel button
+        /// 8  : 4th button (typically the "Browser Back" button)
+        /// 16 : 5th button (typically the "Browser Forward" button)
+        /// </summary>
+        public readonly int Buttons;
+
+        /// <summary>
+        /// Returns the horizontal coordinate within the application's client area at which the event occurred (as opposed to the coordinates within the page). For example, clicking in the top-left corner of the client area will always result in a mouse event with a clientX value of 0, regardless of whether the page is scrolled horizontally.
+        /// </summary>
+        public readonly int ClientX;
+
+        /// <summary>
+        /// Returns the vertical coordinate within the application's client area at which the event occurred (as opposed to the coordinates within the page). For example, clicking in the top-left corner of the client area will always result in a mouse event with a clientY value of 0, regardless of whether the page is scrolled vertically.
+        /// </summary>
+        public readonly int ClientY;
+
+        /// <summary>
+        /// Indicates whether the CTRL key was pressed when the event fired.
+        /// </summary>
+        public readonly bool CtrlKey;
+
+        /// <summary>
+        /// Returns additional numerical information about the event, depending on the type of event.
+        /// For mouse events, such as click, dblclick, mousedown, or mouseup, the detail property indicates how many times the mouse has been clicked in the same location for this event.
+        /// For a dblclick event the value of detail is always 2.
+        /// </summary>
+        public new readonly int Detail;
+
+        /// <summary>
+        /// Indicates whether the "meta" key was pressed when the event fired.
+        /// Note: On the Macintosh, this is the Command key. On Microsoft Windows, this is the Windows key.
+        /// </summary>
+        public readonly bool MetaKey;
+
+        /// <summary>
+        /// Returns the horizontal coordinate of the event within the screen as a whole.
+        /// </summary>
+        public readonly int ScreenX;
+
+        /// <summary>
+        /// Returns the vertical coordinate of the event within the screen as a whole.
+        /// </summary>
+        public readonly int ScreenY;
+
+        /// <summary>
+        /// Indicates whether the SHIFT key was pressed when the event fired.
+        /// </summary>
+        public readonly bool ShiftKey;
+
+        /// <summary>
+        /// The secondary target for the event, if there is one.
+        /// </summary>
+        public readonly Element RelatedTarget;
     }
 }

--- a/jQuery2/Events/Form.cs
+++ b/jQuery2/Events/Form.cs
@@ -36,6 +36,16 @@ namespace Bridge.jQuery2
         /// <summary>
         /// Bind an event handler to the "blur" JavaScript event
         /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        public virtual jQuery Blur(Action<jQueryFocusEvent> handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "blur" JavaScript event
+        /// </summary>
         /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
@@ -80,6 +90,16 @@ namespace Bridge.jQuery2
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
         public virtual jQuery Change(Action handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "change" JavaScript event
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        public virtual jQuery Change(Action<jQueryUiEvent> handler)
         {
             return null;
         }
@@ -138,6 +158,16 @@ namespace Bridge.jQuery2
         /// <summary>
         /// Bind an event handler to the "focus" JavaScript event
         /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        public virtual jQuery Focus(Action<jQueryFocusEvent> handler)
+        {
+          return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "focus" JavaScript event
+        /// </summary>
         /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
@@ -182,6 +212,17 @@ namespace Bridge.jQuery2
         /// <summary>
         /// Bind an event handler to the "focusin" JavaScript event
         /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("focusin({0})")]
+        public virtual jQuery FocusIn(Action<jQueryFocusEvent> handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "focusin" JavaScript event
+        /// </summary>
         /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
@@ -199,6 +240,63 @@ namespace Bridge.jQuery2
         /// <returns>The jQuery instance</returns>
         [Template("focusin({0},{1})")]
         public virtual jQuery FocusIn(object eventData, Action handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "focusout" JavaScript event.
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("focusout({0})")]
+        public virtual jQuery FocusOut(Delegate handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "focusout" JavaScript event.
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("focusout({0})")]
+        public virtual jQuery FocusOut(Action handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "focusout" JavaScript event.
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("focusout({0})")]
+        public virtual jQuery FocusOut(Action<jQueryFocusEvent> handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "focusout" JavaScript event.
+        /// </summary>
+        /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("focusout({0},{1})")]
+        public virtual jQuery FocusOut(object eventData, Delegate handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "focusout" JavaScript event.
+        /// </summary>
+        /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("focusout({0},{1})")]
+        public virtual jQuery FocusOut(object eventData, Action handler)
         {
             return null;
         }
@@ -228,6 +326,16 @@ namespace Bridge.jQuery2
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
         public virtual jQuery Select(Action handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "select" JavaScript event
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        public virtual jQuery Select(Action<jQueryUiEvent> handler)
         {
             return null;
         }
@@ -279,6 +387,16 @@ namespace Bridge.jQuery2
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
         public virtual jQuery Submit(Action handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "submit" JavaScript event
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        public virtual jQuery Submit(Action<jQueryUiEvent> handler)
         {
             return null;
         }

--- a/jQuery2/Events/Keyboard.cs
+++ b/jQuery2/Events/Keyboard.cs
@@ -5,52 +5,6 @@ namespace Bridge.jQuery2
     public partial class jQuery
     {
         /// <summary>
-        /// Bind an event handler to the "focusout" JavaScript event.
-        /// </summary>
-        /// <param name="handler">A function to execute each time the event is triggered.</param>
-        /// <returns>The jQuery instance</returns>
-        [Template("focusout({0})")]
-        public virtual jQuery FocusOut(Delegate handler)
-        {
-            return null;
-        }
-
-        /// <summary>
-        /// Bind an event handler to the "focusout" JavaScript event.
-        /// </summary>
-        /// <param name="handler">A function to execute each time the event is triggered.</param>
-        /// <returns>The jQuery instance</returns>
-        [Template("focusout({0})")]
-        public virtual jQuery FocusOut(Action handler)
-        {
-            return null;
-        }
-
-        /// <summary>
-        /// Bind an event handler to the "focusout" JavaScript event.
-        /// </summary>
-        /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
-        /// <param name="handler">A function to execute each time the event is triggered.</param>
-        /// <returns>The jQuery instance</returns>
-        [Template("focusout({0},{1})")]
-        public virtual jQuery FocusOut(object eventData, Delegate handler)
-        {
-            return null;
-        }
-
-        /// <summary>
-        /// Bind an event handler to the "focusout" JavaScript event.
-        /// </summary>
-        /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
-        /// <param name="handler">A function to execute each time the event is triggered.</param>
-        /// <returns>The jQuery instance</returns>
-        [Template("focusout({0},{1})")]
-        public virtual jQuery FocusOut(object eventData, Action handler)
-        {
-            return null;
-        }
-
-        /// <summary>
         /// Trigger the "keydown" JavaScript event on an element.
         /// </summary>
         /// <returns>The jQuery instance</returns>
@@ -78,6 +32,17 @@ namespace Bridge.jQuery2
         /// <returns>The jQuery instance</returns>
         [Template("keydown({0})")]
         public virtual jQuery KeyDown(Action handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "keydown" JavaScript event.
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("keydown({0})")]
+        public virtual jQuery KeyDown(Action<jQueryKeyboardEvent> handler)
         {
             return null;
         }
@@ -141,6 +106,17 @@ namespace Bridge.jQuery2
         /// <summary>
         /// Bind an event handler to the "keypress" JavaScript event.
         /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("keypress({0})")]
+        public virtual jQuery KeyPress(Action<jQueryKeyboardEvent> handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "keypress" JavaScript event.
+        /// </summary>
         /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
@@ -192,6 +168,18 @@ namespace Bridge.jQuery2
         public virtual jQuery KeyUp(Action handler)
         {
             return null;
+        }
+
+
+        /// <summary>
+        /// Bind an event handler to the "keyup" JavaScript event.
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("keyup({0})")]
+        public virtual jQuery KeyUp(Action<jQueryKeyboardEvent> handler)
+        {
+          return null;
         }
 
         /// <summary>

--- a/jQuery2/Events/Mouse.cs
+++ b/jQuery2/Events/Mouse.cs
@@ -1,4 +1,3 @@
-using Bridge.Html5;
 using System;
 
 namespace Bridge.jQuery2
@@ -39,7 +38,7 @@ namespace Bridge.jQuery2
         /// </summary>
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
-        public virtual jQuery Click(Action<Event> handler)
+        public virtual jQuery Click(Action<jQueryMouseEvent> handler)
         {
             return null;
         }
@@ -101,6 +100,17 @@ namespace Bridge.jQuery2
         /// <summary>
         /// Bind an event handler to the "dblclick" JavaScript event.
         /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("dblclick({0})")]
+        public virtual jQuery DblClick(Action<jQueryMouseEvent> handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "dblclick" JavaScript event.
+        /// </summary>
         /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
@@ -138,6 +148,16 @@ namespace Bridge.jQuery2
         /// <param name="handler">A function to execute when the mouse pointer enters or leaves the element.</param>
         /// <returns>The jQuery instance</returns>
         public virtual jQuery Hover(Action handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind a single handler to the matched elements, to be executed when the mouse pointer enters or leaves the elements.
+        /// </summary>
+        /// <param name="handler">A function to execute when the mouse pointer enters or leaves the element.</param>
+        /// <returns>The jQuery instance</returns>
+        public virtual jQuery Hover(Action<jQueryMouseEvent> handler)
         {
             return null;
         }
@@ -192,6 +212,17 @@ namespace Bridge.jQuery2
         /// <returns>The jQuery instance</returns>
         [Template("mousedown({0})")]
         public virtual jQuery MouseDown(Action handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "mousedown" JavaScript event.
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("mousedown({0})")]
+        public virtual jQuery MouseDown(Action<jQueryMouseEvent> handler)
         {
             return null;
         }
@@ -255,6 +286,17 @@ namespace Bridge.jQuery2
         /// <summary>
         /// Bind an event handler to the "mouseenter" JavaScript event.
         /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("mouseenter({0})")]
+        public virtual jQuery MouseEnter(Action<jQueryMouseEvent> handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "mouseenter" JavaScript event.
+        /// </summary>
         /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
@@ -304,6 +346,17 @@ namespace Bridge.jQuery2
         /// <returns>The jQuery instance</returns>
         [Template("mouseleave({0})")]
         public virtual jQuery MouseLeave(Action handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "mouseleave" JavaScript event.
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("mouseleave({0})")]
+        public virtual jQuery MouseLeave(Action<jQueryMouseEvent> handler)
         {
             return null;
         }
@@ -367,6 +420,17 @@ namespace Bridge.jQuery2
         /// <summary>
         /// Bind an event handler to the "mousemove" JavaScript event.
         /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("mousemove({0})")]
+        public virtual jQuery MouseMove(Action<jQueryMouseEvent> handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "mousemove" JavaScript event.
+        /// </summary>
         /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
@@ -418,6 +482,17 @@ namespace Bridge.jQuery2
         public virtual jQuery MouseOut(Action handler)
         {
             return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "mouseout" JavaScript event.
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("mouseout({0})")]
+        public virtual jQuery MouseOut(Action<jQueryMouseEvent> handler)
+        {
+          return null;
         }
 
         /// <summary>
@@ -479,6 +554,17 @@ namespace Bridge.jQuery2
         /// <summary>
         /// Bind an event handler to the "mouseover" JavaScript event.
         /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("mouseover({0})")]
+        public virtual jQuery MouseOver(Action<jQueryMouseEvent> handler)
+        {
+          return null;
+        }
+        
+        /// <summary>
+        /// Bind an event handler to the "mouseover" JavaScript event.
+        /// </summary>
         /// <param name="eventData">An object containing data that will be passed to the event handler.</param>
         /// <param name="handler">A function to execute each time the event is triggered.</param>
         /// <returns>The jQuery instance</returns>
@@ -528,6 +614,17 @@ namespace Bridge.jQuery2
         /// <returns>The jQuery instance</returns>
         [Template("mouseup({0})")]
         public virtual jQuery MouseUp(Action handler)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Bind an event handler to the "mouseup" JavaScript event.
+        /// </summary>
+        /// <param name="handler">A function to execute each time the event is triggered.</param>
+        /// <returns>The jQuery instance</returns>
+        [Template("mouseup({0})")]
+        public virtual jQuery MouseUp(Action<jQueryMouseEvent> handler)
         {
             return null;
         }


### PR DESCRIPTION
Fix issue #16 by refactoring the jQuery event class to more closely
match the HTML5 event class and by adding overloads for all the event
methods accepting an Action<EVENT_TYPE> parameter.